### PR TITLE
Fixes for dimension matching

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -155,6 +155,9 @@ func scrape(collector *cwCollector, ch chan<- prometheus.Metric) {
 			for _,dim := range met.Dimensions {
 				dimRegex:=metric.ConfMetric.DimensionsSelectRegex[*dim.Name]
 				if(dimRegex==""){
+					if (len(metric.ConfMetric.DimensionsSelect[*dim.Name]) == 0){
+						continue
+					}
 					dimRegex="\\b"+strings.Join(metric.ConfMetric.DimensionsSelect[*dim.Name],"\\b|\\b")+"\\b"
 				}
 


### PR DESCRIPTION
cloudwatch_exporter is currently returning metrics for dimensions not listed in aws_dimensions, i.e

```yaml 
      - aws_namespace: "AWS/RDS"
        aws_dimensions: [DBInstanceIdentifier]
        aws_metric_name: CPUUtilization
        aws_statistics: [Average]
        range_seconds: 60
```
```
aws_rds_cpu_utilization_average{db_instance_identifier="rds-us-east-1-test",task="all"} 2.5083333333333333
aws_rds_cpu_utilization_average{db_instance_identifier="database-1",task="all"} 2.275
aws_rds_cpu_utilization_average{db_instance_identifier="database-2",task="all"} 8.549999999999999
aws_rds_cpu_utilization_average{db_instance_identifier="database-3",task="all"} 2.3249999999999997
aws_rds_cpu_utilization_average{db_instance_identifier="db.m5.large",task="all"} 5.529166666666666
aws_rds_cpu_utilization_average{db_instance_identifier="db.m6g.large",task="all"} 2.3249999999999997
aws_rds_cpu_utilization_average{db_instance_identifier="db.r6g.large",task="all"} 2.275
aws_rds_cpu_utilization_average{db_instance_identifier="mysql",task="all"} 2.369444444444444
aws_rds_cpu_utilization_average{db_instance_identifier="sqlserver-se",task="all"} 8.549999999999999
```
`mysql` and `db.m6g.large` are not DBInstanceIdentifier they are from the `DatabaseClass` and `EngineName` dimension and should be filtered out.

This PR adresses this issue. 
Tests:
```yaml 
      - aws_namespace: "AWS/RDS"
        aws_dimensions: [DBInstanceIdentifier]
        aws_metric_name: CPUUtilization
        aws_statistics: [Average]
        range_seconds: 60
```
```
aws_rds_cpu_utilization_average{db_instance_identifier="rds-us-east-1-test",task="all"} 2.1
aws_rds_cpu_utilization_average{db_instance_identifier="database-1",task="all"} 2.066666666666667
aws_rds_cpu_utilization_average{db_instance_identifier="database-2",task="all"} 7.758333333333335
aws_rds_cpu_utilization_average{db_instance_identifier="database-3",task="all"} 2.125
```
```yaml
      - aws_namespace: "AWS/RDS"
        aws_dimensions: [DBInstanceIdentifier]
        aws_dimensions_select_regex:
          DBInstanceIdentifier: "database.*"
        aws_metric_name: CPUUtilization
        aws_statistics: [Average]
        range_seconds: 60
```
```
aws_rds_cpu_utilization_average{db_instance_identifier="database-1",task="all"} 2.166666666666667
aws_rds_cpu_utilization_average{db_instance_identifier="database-2",task="all"} 7.766666666666666
aws_rds_cpu_utilization_average{db_instance_identifier="database-3",task="all"} 2.2416666666666667
```
```yaml
      - aws_namespace: "AWS/RDS"
        aws_dimensions: [DBInstanceIdentifier]
        aws_dimensions_select:
          DBInstanceIdentifier: [database-1]
        aws_metric_name: CPUUtilization
        aws_statistics: [Average]
        range_seconds: 60
```
```
aws_rds_cpu_utilization_average{db_instance_identifier="database-1",task="all"} 2.3416666666666663
```
```yaml
      - aws_namespace: "AWS/RDS"
        aws_dimensions: [DBInstanceIdentifier, DatabaseClass]
        aws_metric_name: CPUUtilization
        aws_statistics: [Average]
        range_seconds: 60
```
```
## Returns nothing, same result was returned before the change.
## Each dimension should go in a separate metrics entry 
```